### PR TITLE
Corrects imports for MeteorJS.

### DIFF
--- a/relaxed-json.js
+++ b/relaxed-json.js
@@ -574,9 +574,10 @@
   };
 
   /* global window, module */
-  if (typeof module !== "undefined") {
+  if (typeof window !== "undefined") {
     window.RJSON = RJSON;
-  } else if (typeof window !== "undefined") {
+  }
+  if (typeof module !== "undefined") {
     module.exports = RJSON;
   }
 }());

--- a/relaxed-json.js
+++ b/relaxed-json.js
@@ -574,9 +574,9 @@
   };
 
   /* global window, module */
-  if (typeof window !== "undefined") {
+  if (typeof module !== "undefined") {
     window.RJSON = RJSON;
-  } else if (typeof module !== "undefined") {
+  } else if (typeof window !== "undefined") {
     module.exports = RJSON;
   }
 }());

--- a/test/tests.js
+++ b/test/tests.js
@@ -75,6 +75,10 @@ describe("transform()", function () {
     it("strips multi-line comments", function () {
       relaxation("[ true,  /* comment \n  */ false]", [true, false]);
     });
+
+    it("allows number as keys", function () {
+      relaxation("{ 0 : 'value'}", { 0 : 'value'});
+    });
   });
 
   describe("error cases", function () {


### PR DESCRIPTION
Also adds test for number:  RJSON.parse('{2:"hello"}') => { "2" : "hello" } 