### PR TITLE
Add `tolerant` option to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ features helping writing JSON by hand.
   You could pass a reviver function or an options object as the second argument. Supported options:
   - `reviver`: you could still pass a reviver
   - `relaxed`: use relaxed version of JSON (default: true)
-  - `warnings`: use relaxed JSON own parser, supports better error messages (default: false).
+  - `warnings`: use relaxed JSON own parser, supports better error messages (default: false)
+  - `tolerant`: wait until the end to throw errors
   - `duplicate`: fail if there are duplicate keys in objects
 
 ## Executable


### PR DESCRIPTION
Adding [TypeScript](typescriptlang.org) types to [DefinitelyTyped](http://definitelytyped.org/). They prefer one [works from documentation](https://typescript.codeplex.com/wikipage?title=Writing%20Definition%20%28.d.ts%29%20Files), and it was mentioned in a [pull request review](
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15744) that `tolerant` wasn't in the documentation.

Added `tolerant` to `README.md` so people know it's an option.