### PR TITLE
Export module or set global variable, but not both

### DIFF
--- a/relaxed-json.js
+++ b/relaxed-json.js
@@ -580,11 +580,9 @@
   };
 
   /* global window, module */
-  if (typeof window !== "undefined") {
-    window.RJSON = RJSON;
-  }
-
   if (typeof module !== "undefined") {
     module.exports = RJSON;
+  } else if (typeof window !== "undefined") {
+    window.RJSON = RJSON;
   }
 }());


### PR DESCRIPTION
This prevents the library from being both exported and set as a global variable in a webpack build.